### PR TITLE
Remove case sensitivity on text checking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             egui::ScrollArea::vertical().show(ui, |ui| {
                 for var in it {
                     let text = var.as_ref();
-                    if !buf.is_empty() && !text.contains(&*buf) {
+                    if !buf.is_empty() && !text.to_lowercase().contains(&buf.to_lowercase()) {
                         continue;
                     }
 


### PR DESCRIPTION
**Changes:**
* Text checks are now done using lowercase which removes the case sensitivity, allowing results to be visible without maintaining the exact case

@ItsEthra Please let me know if you are not happy with something. Thank you!