### PR TITLE
implement config for width, focus behavior and filtering

### DIFF
--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -11,12 +11,20 @@ impl App for ExampleApp {
     fn update(&mut self, ctx: &Context, _: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.horizontal(|ui| {
-                ui.add(DropDownBox::from_iter(
-                    &self.items,
-                    "test_dropbox",
-                    &mut self.buf,
-                    |ui, text| ui.selectable_label(false, text),
-                ));
+                ui.add(
+                    DropDownBox::from_iter(
+                        &self.items,
+                        "test_dropbox",
+                        &mut self.buf,
+                        |ui, text| ui.selectable_label(false, text),
+                    )
+                    // choose wether to filter the box items based on what is in the text edit already
+                    // default is true when this is not used
+                    .filter_by_input(false)
+                    // choose wether to select all text in the text edit when it gets focused
+                    // default is false when this is not used
+                    .select_on_focus(true),
+                );
 
                 if ui.button("Add").clicked() {
                     self.items.push(self.buf.clone());

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -23,7 +23,10 @@ impl App for ExampleApp {
                     .filter_by_input(false)
                     // choose wether to select all text in the text edit when it gets focused
                     // default is false when this is not used
-                    .select_on_focus(true),
+                    .select_on_focus(true)
+                    // passes through the desired width to the text edit
+                    // default is None internally, so TextEdit does whatever its default implements
+                    .desired_width(250.0),
                 );
 
                 if ui.button("Add").clicked() {

--- a/examples/dropdown.rs
+++ b/examples/dropdown.rs
@@ -18,10 +18,10 @@ impl App for ExampleApp {
                         &mut self.buf,
                         |ui, text| ui.selectable_label(false, text),
                     )
-                    // choose wether to filter the box items based on what is in the text edit already
+                    // choose whether to filter the box items based on what is in the text edit already
                     // default is true when this is not used
-                    .filter_by_input(false)
-                    // choose wether to select all text in the text edit when it gets focused
+                    .filter_by_input(true)
+                    // choose whether to select all text in the text edit when it gets focused
                     // default is false when this is not used
                     .select_on_focus(true)
                     // passes through the desired width to the text edit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub struct DropDownBox<
     hint_text: WidgetText,
     filter_by_input: bool,
     select_on_focus: bool,
+    desired_width: Option<f32>,
 }
 
 impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = V>>
@@ -42,6 +43,7 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             hint_text: WidgetText::default(),
             filter_by_input: true,
             select_on_focus: false,
+            desired_width: None,
         }
     }
 
@@ -62,6 +64,12 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
         self.select_on_focus = select_on_focus;
         self
     }
+
+    /// Passes through the desired width value to the underlying Text Edit
+    pub fn desired_width(mut self, desired_width: f32) -> Self {
+        self.desired_width = desired_width.into();
+        self
+    }
 }
 
 impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = V>> Widget
@@ -76,11 +84,14 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             hint_text,
             filter_by_input,
             select_on_focus,
+            desired_width,
         } = self;
 
-        let edit = TextEdit::singleline(buf).hint_text(hint_text);
+        let mut edit = TextEdit::singleline(buf).hint_text(hint_text);
+        if let Some(dw) = desired_width {
+            edit = edit.desired_width(dw);
+        }
         let mut edit_output = edit.show(ui);
-        // let mut r = ui.add(edit);
         let mut r = edit_output.response;
         if r.gained_focus() {
             if select_on_focus {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub struct DropDownBox<
     display: F,
     it: I,
     hint_text: WidgetText,
+    filter_by_input: bool,
 }
 
 impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = V>>
@@ -35,12 +36,19 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             display,
             buf,
             hint_text: WidgetText::default(),
+            filter_by_input: true,
         }
     }
 
     /// Add a hint text to the Text Edit
     pub fn hint_text(mut self, hint_text: impl Into<WidgetText>) -> Self {
         self.hint_text = hint_text.into();
+        self
+    }
+
+    /// Determine wether to filter box items based on what is in the Text Edit already
+    pub fn filter_by_input(mut self, filter_by_input: bool) -> Self {
+        self.filter_by_input = filter_by_input;
         self
     }
 }
@@ -55,6 +63,7 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             it,
             mut display,
             hint_text,
+            filter_by_input,
         } = self;
 
         let mut r = ui.add(TextEdit::singleline(buf).hint_text(hint_text));
@@ -67,7 +76,10 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
             egui::ScrollArea::vertical().show(ui, |ui| {
                 for var in it {
                     let text = var.as_ref();
-                    if !buf.is_empty() && !text.to_lowercase().contains(&buf.to_lowercase()) {
+                    if filter_by_input
+                        && !buf.is_empty()
+                        && !text.to_lowercase().contains(&buf.to_lowercase())
+                    {
                         continue;
                     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,13 @@ impl<'a, F: FnMut(&mut Ui, &str) -> Response, V: AsRef<str>, I: Iterator<Item = 
         self
     }
 
-    /// Determine wether to filter box items based on what is in the Text Edit already
+    /// Determine whether to filter box items based on what is in the Text Edit already
     pub fn filter_by_input(mut self, filter_by_input: bool) -> Self {
         self.filter_by_input = filter_by_input;
         self
     }
 
-    /// Determine wether to select the text when the Text Edit gains focus
+    /// Determine whether to select the text when the Text Edit gains focus
     pub fn select_on_focus(mut self, select_on_focus: bool) -> Self {
         self.select_on_focus = select_on_focus;
         self


### PR DESCRIPTION
closes #8

I have added the features discussed in the ticket, was easier than I thought.
I would appreciate a merge and new release, I think we should not clutter the
ecosystem with a bunch of variants/forks.

This is all backwards compatible.
I kept the behavior at what it does currently unless the new functions get used.