### PR TITLE
Exclude examples and media folders from crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/ItsEthra/egui-dropdown"
 authors = ["ItsEthra"]
 readme = "README.md"
+exclude = ["/examples", "/media"]
 
 [dependencies]
 egui = "0.28.1"


### PR DESCRIPTION
Hello, @ItsEthra, I have updated the `Cargo.toml` file to exclude the `examples` and `media` folders from uploading to crates.io which should reduce the size of the lib by quite a bit. Let me know what you think!