### PR TITLE
Add unidecode feature support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ authors = ["ItsEthra"]
 readme = "README.md"
 exclude = ["/examples", "/media"]
 
+[features]
+unidecode = ["dep:unidecode"]
+
 [dependencies]
 egui = { version = "0.31", default-features = false }
+unidecode = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 eframe = "0.31"


### PR DESCRIPTION
Adding the feature unidecode so that we can filter the dropdown results excluding accent marks
This uses the crate https://github.com/chowdhurya/rust-unidecode